### PR TITLE
Capitalize name for contributors button

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -145,9 +145,9 @@ This endpoint generates a GitHub badge containing the count of minted GitPOAPs f
 Using `ethereum/ethereum-org-website` as an example via [https://public-api.gitpoap.io/v1/repo/ethereum/ethereum-org-website/badge](https://public-api.gitpoap.io/v1/repo/ethereum/ethereum-org-website/badge), embed the badge in a `.md` file the following way:
 
 ```markdown
-[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/gitpoap/gitpoap-docs/badge)](https://www.gitpoap.io/gh/gitpoap/gitpoap-docs)
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/gitpoap/gitpoap-docs/badge)](https://www.gitpoap.io/gh/gitpoap/gitpoap-docs)
 ```
 
 Resulting in the following:
 
-[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/gitpoap/gitpoap-docs/badge)](https://www.gitpoap.io/gh/gitpoap/gitpoap-docs)
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/gitpoap/gitpoap-docs/badge)](https://www.gitpoap.io/gh/gitpoap/gitpoap-docs)


### PR DESCRIPTION
This follows what most of the other badges I've been seeing do