### PR TITLE
bug-fix: sidebar collapse button now works as expected

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -17,7 +17,7 @@ const sidebars = {
     {
       type: 'category',
       label: '+ Getting Started',
-      collapsible: false,
+      collapsible: true,
       items: [
         {
           type: 'doc',
@@ -38,8 +38,8 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Advanced',
-      collapsible: false,
+      label: '+ Advanced',
+      collapsible: true,
       items: [
         {
           type: 'doc',


### PR DESCRIPTION
This PR fixes how the sidebar's dropdown/collapse functionality should work. Earlier, the `+` symbol was present for _Getting Started_, which indicated that the sub-headings should be collapsible. This PR solves that, and also adds a `+` symbol to the _Advanced_ heading along with the functionality.