### PR TITLE
Typo Update faq.mdx

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -24,6 +24,6 @@ This, however, is an area of research and focus for us and we strive to do what�
 
 Our goal is to build a trusted record of software contributions on chain. We are concerned that if we are open source from the start, it may dilute the quality of information coming on chain. We aim to open source as much of our platform as possible, but since there are many unknown unknowns we’ll be mostly closed source at the start.
 
-## Wen GitLab, Bitbucket, radicle, etc?
+## Wen GitLab, Bitbucket, Radicle, etc?
 
 We’re focused on GitHub for now, but we’ll be integrating into other code repositories as well as non-software contribution tools in the future. If you have a particular request, drop us a message at team@gitpoap.io.


### PR DESCRIPTION
"radicle" is written in lowercase, but "**Radicle**" is the proper name of a product/project, so it should be capitalized.

Corrected: "**When GitLab, Bitbucket, Radicle, etc?**"