### PR TITLE
Fix typos and improve wording in api.mdx

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -234,7 +234,7 @@ the following: `claimed`, `unclaimed`, `pending`, `minting`, and can be omitted 
 
 ### `GET /v1/repo/:owner/:name/badge`
 
-This endpoint generates a GitHub badge containing the count of minted GitPOAPs for a specified repo. The repo is specified with a GitHub owner and repo name & the endpoint will return a SVG for use in any `.md` file such as a `README.md`.
+This endpoint generates a GitHub badge containing the count of minted GitPOAPs for a specified repo. The repo is specified with a GitHub owner and repo name & the endpoint will return an SVG for use in any `.md` file such as a `README.md`.
 
 Using `ethereum/ethereum-org-website` as an example via [https://public-api.gitpoap.io/v1/repo/ethereum/ethereum-org-website/badge](https://public-api.gitpoap.io/v1/repo/ethereum/ethereum-org-website/badge), embed the badge in a `.md` file the following way:
 

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -16,7 +16,7 @@ If you have any questions, comments, or suggestions, please reach out in the #gi
 ## Version 1
 
 **Note that the public API limits individual IPs to a
-maximum of 100 requests within a 5 minute window.**
+maximum of 100 requests within a 5-minute window.**
 
 ### `GET /v1/poap/:poapTokenId/is-gitpoap`
 

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -183,7 +183,7 @@ This endpoint allows users to query for a list of all addresses that hold any Gi
 
 ### `GET /v1/address/:address/gitpoaps`
 
-This endpoint allows users to query for some address's (either an ETH or ENS address) GitPOAPs. This returns data like:
+This endpoint allows users to query for some addresses (either an ETH or ENS address) GitPOAPs. This returns data like:
 
 ```json
 [


### PR DESCRIPTION
This pull request addresses several minor typos and wording improvements in the `api.mdx` file:
- Corrected the hyphenation in "5 minute" to "5-minute."
- Fixed possessive usage of "address's" to the plural form "addresses."
- Added a missing article "a" in a sentence.

These changes ensure clarity and consistency in the documentation.
